### PR TITLE
Split StatsSamples into TimeHist & VoteHist

### DIFF
--- a/nano_prom_exporter/nanoStats.py
+++ b/nano_prom_exporter/nanoStats.py
@@ -144,13 +144,21 @@ class nanoProm:
             ["type", "detail", "dir"],
             registry=registry,
         )
-        self.StatsSamples = Histogram(
+        self.StatsSamplesTimeHist = Histogram(
             "nano_stats_samples",
             "Stats Samples",
             ["sample"],
             registry=registry,
             cumulative=False,
             buckets=[.1, .5, 1, 1.5, 3, 5.0, 7.5, 10.0, 15.0, 30.0, 45.0, 60.0, 90.0, 120.0, 240.0, 300.0, 600.0, inf]
+        )
+        self.StatsSamplesVoteHist = Histogram(
+            "nano_stats_samples_votes",
+            "Stats Samples (Vote Packaging Size)",
+            ["sample"],
+            registry=registry,
+            cumulative=False,
+            buckets=[1, 10, 20, 50, 100, 150, 200, 250, 255, float('inf')]
         )
         self.StatsObjectsCount = Gauge(
             "nano_stats_objects_count",
@@ -398,8 +406,12 @@ class nanoProm:
             )
 
         for entry in stats.StatsSamples["entries"]:
-            for value in entry["values"]:
-                self.StatsSamples.labels(entry["sample"]).observe(int(value) / 1000) # milliseconds to seconds
+            if entry["max"] == "255":
+                for value in entry["values"]:
+                    self.StatsSamplesVoteHist.labels(sample=entry["sample"]).observe(int(value))
+            else:
+                for value in entry["values"]:
+                    self.StatsSamplesTimeHist.labels(entry["sample"]).observe(int(value) / 1000) # milliseconds to seconds
 
         self.Version.info(
             {


### PR DESCRIPTION
With https://github.com/nanocurrency/nano-node/pull/4751 the Samples are not always reporting a value in miliseconds.
This adds a VoteHistogram that is populated when the samples_entry `max` equals 255.

There might be a better test to make the distinction. But currently this works fine in my tests.